### PR TITLE
Feature/Youtube url paste

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ npm-debug.log*
 *.sublime-project
 *.sublime-workspace
 
+# Vim config
+.vimrc
+
+# Startup script
+start.sh
+
 # Runtime data
 pids
 *.pid

--- a/public/badass-client.js
+++ b/public/badass-client.js
@@ -6,7 +6,7 @@ $('#message').on('keyup', function(e){
 
 		//Send msg
 		socket.emit('chat_msg', message);
-		
+
 		addMessage(message);
 
 		//Clear text in input
@@ -16,8 +16,10 @@ $('#message').on('keyup', function(e){
 
 $('#newSong').on('keyup', function(e){
 	if(e.keyCode == 13){
+		var id = getIdFromYoutubeUrl($(this).val());
+
 		//Send msg
-		socket.emit('new_song', $(this).val());
+		socket.emit('new_song', id);
 
 		//Clear text in input
 		$(this).val('');
@@ -92,9 +94,9 @@ function renderSong(song) {
 	// Default votes to 0
 	song.votes = song.votes || 0;
 
-	return '<a href="https://youtube.com/watch?v=' + song.youtubeId + '" target="_blank">' 
-		+ song.title 
-		+ '</a> - ' 
+	return '<a href="https://youtube.com/watch?v=' + song.youtubeId + '" target="_blank">'
+		+ song.title
+		+ '</a> - '
 		+ ((song.playTime) ? song.playTime : song.duration) + 'sec. '
 		+ '<button class="btn-vote" data-song-id="' + song.id + '">Vote up (' + song.votes + ')</button>'
 	;
@@ -108,4 +110,18 @@ function addMessage(message) {
 	$('#text').append('<p>Message: '+ $('<div/>').text(message).html() +'</p>');
 
 	$('#text').scrollTop(999999999);
+}
+
+function isURL(str) {
+	return /^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})).?)(?::\d{2,5})?(?:[/?#]\S*)?$/i.test(str);
+}
+
+function getIdFromYoutubeUrl(url) {
+	var id = "";
+	if (! isURL(url) && url.length == 11) {
+		return url;
+	}
+	var r = new RegExp('^.*(?:youtu.be\/|v\/|e\/|u\/\w+\/|embed\/|v=)([^#\&\?]*).*');
+	var m = url.match(r);
+	return m[1];
 }

--- a/public/client.html
+++ b/public/client.html
@@ -31,7 +31,7 @@
 		<div>Now playing: <span id="song-info"><i>Nothing yet, add a song below</i></span></div>
 		<div id='related-songs'></div>
 		<div>Queue: <i>(Highest voted will play first)</i> <div id="queue-info">-</div></div>
-		<div>Add a song to queue: <input id="newSong" placeholder="youtubeidhere" /></div>
+		<div>Add a song to queue: <input id="newSong" placeholder="Paste youtube URL or ID here..." style="width: 250px;"/></div>
 	</div>
 </div>
 

--- a/start.sh.sample
+++ b/start.sh.sample
@@ -1,0 +1,3 @@
+# Visit https://console.developers.google.com/apis/credentials to get one
+export YOUTUBE_API_KEY=<YOUR GOOGLE API KEY HERE>
+node radio


### PR DESCRIPTION
I changed the `Add a song to the queue` textbox to accept a full Youtube URLs, for easier copy/pasting. The video ID gets extracted from the URL and sent to the server, once you hit enter. You can also continue to use only the video ID.
