### PR TITLE
Feature/remove from queue

### DIFF
--- a/public/badass-client.js
+++ b/public/badass-client.js
@@ -28,6 +28,10 @@ $('body').on('click', '.btn-vote', function() {
 	socket.emit('vote', $(this).data('song-id'));
 });
 
+$('body').on('click', '.btn-delete', function() {
+	socket.emit('delete_queued', $(this).data('song-id'));
+});
+
 $('body').on('click', '.add-song', function() {
 	socket.emit('new_song', $(this).data('youtube-id'));
 });
@@ -60,7 +64,13 @@ socket.on('queue_info', function(data) {
 	$queue_info = $queue_info.find('ol');
 
 	for(var song in data) {
-		$queue_info.append('<li>' + renderSong(data[song]) + '</li>');
+		var o = data[song];
+		var addedBy = o.addedBy.substring(2);
+		var deleteButton = '';
+		if (addedBy == socket.id) {
+			deleteButton = '<button class="btn-delete" data-song-id="' + o.id + '">Remove</button>';
+		}
+		$queue_info.append('<li>' + renderSong(o) + deleteButton + '</li>');
 	}
 });
 

--- a/public/badass-client.js
+++ b/public/badass-client.js
@@ -6,7 +6,7 @@ $('#message').on('keyup', function(e){
 
 		//Send msg
 		socket.emit('chat_msg', message);
-		
+
 		addMessage(message);
 
 		//Clear text in input
@@ -102,9 +102,9 @@ function renderSong(song) {
 	// Default votes to 0
 	song.votes = song.votes || 0;
 
-	return '<a href="https://youtube.com/watch?v=' + song.youtubeId + '" target="_blank">' 
-		+ song.title 
-		+ '</a> - ' 
+	return '<a href="https://youtube.com/watch?v=' + song.youtubeId + '" target="_blank">'
+		+ song.title
+		+ '</a> - '
 		+ ((song.playTime) ? song.playTime : song.duration) + 'sec. '
 		+ '<button class="btn-vote" data-song-id="' + song.id + '">Vote up (' + song.votes + ')</button>'
 	;

--- a/radio.js
+++ b/radio.js
@@ -292,7 +292,7 @@ var Queue = function(ioUsers) {
 
 				// Add the first related video to queue (asynchronous!)
 				if(self.active !== null && self.active.relatedVideos.length) {
-					self.add(self.active.relatedVideos[0].youtubeId);
+					self.add({}, self.active.relatedVideos[0].youtubeId);
 					relatedVideoIsLoading = true;
 				}
 


### PR DESCRIPTION
Added a button that lets users remove songs they've added to the queue list.

When adding a song to the queue, the connection ID is saved in the song object in the queue array. This allows all users to see who added which song when they receive the updated queue information. Currently, I only use this to check if a song has been added by the current user, and then show the `Remove` button.

References issue #18.

Here's what it looks like:
![screen shot 2016-06-10 at 4 50 43 pm](https://cloud.githubusercontent.com/assets/5585316/15968337/2b56f7a4-2f34-11e6-9137-8040ca434def.png)
