### PR TITLE
Fix / Duplicate Songs in Queue

### DIFF
--- a/radio.js
+++ b/radio.js
@@ -247,7 +247,22 @@ var Queue = function(ioUsers) {
 	}
 
 	this.add = function(userSocket, videoId) {
-		var songs = userSocket.songs || [];
+		var self = this;
+
+		// check if song is already playing, prevent adding
+		if(self.active && self.active.youtubeId === videoId) {
+			userSocket.emit('be_alerted', 'This song is currently playing.');
+			return;
+		}
+
+		// check if song already exists in queue, prevent adding
+		var queueItems = self.getItems();
+		for(var index in queueItems) {
+			if(queueItems[index].youtubeId === videoId) {
+				userSocket.emit('be_alerted', 'This song is already in the queue. Try voting for it instead.');
+				return;
+			}
+		}
 
 		youTubeApi.getVideo(videoId, function(data) {
 			if(data.pageInfo.totalResults > 0) {


### PR DESCRIPTION
Changed:
- Added checks for adding duplicate songs in the queue. Users will be_alerted that the song is _already playing_ or _already in the queue_. This will prevent one song being added a gazillion times by mistake or on purpose.
- Removed unused songs variable

Related to:
https://github.com/Bratanov/community-driven-radio/issues/22