### PR TITLE
Fix / Queue Sorting

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,18 @@
     "socket.io": "^1.4.5"
   },
   "devDependencies": {
+    "chai": "^4.1.2",
     "docdash": "^0.4.0",
     "fs-extra": "^2.1.2",
-    "jsdoc": "^3.4.3"
+    "jsdoc": "^3.4.3",
+    "lodash": "^4.17.10",
+    "mocha": "^5.2.0",
+    "sinon": "^6.1.5"
   },
   "scripts": {
     "start": "node radio.js",
     "publish-docs": "node server/scripts/publish-gh-pages.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "keywords": [
     "radio"

--- a/server/core/queue.js
+++ b/server/core/queue.js
@@ -3,6 +3,7 @@ const Song = require('./song.js');
 const Logger = require('./logger.js');
 const YoutubeApi = require('./youtube-api.js');
 const youTubeApi = new YoutubeApi(process.env.YOUTUBE_API_KEY);
+const _ = require('lodash');
 
 /**
  * Contains the list of songs and plays the next one at the correct time
@@ -64,23 +65,10 @@ class Queue {
 	 * @return {[Song]} Array of song items, sorted by votes/position
 	 */
 	getItems() {
-		// Make a fresh copy of the original items
-		let copyItems = this.items.slice();
-
-		// sort by votes
-		copyItems.sort((item1, item2) => {
-			if(item1.votes > item2.votes) {
-				return -1;
-			}
-
-			if(item1.votes < item2.votes) {
-				return 1;
-			}
-
-			return 0;
-		});
-
-		return copyItems;
+		// sort by votes, using lodash's *stable* sorting
+		// in order to preserve the original order of
+		// similar voted songs based on time added
+		return _.sortBy(this.items, (item) => item.votes);
 	}
 
 	/**

--- a/test/server/core/queue.test.js
+++ b/test/server/core/queue.test.js
@@ -1,0 +1,67 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const _ = require('lodash');
+const expect = chai.expect;
+const Queue = require('../../../server/core/queue');
+
+describe('Queue', function() {
+	let queue;
+	let client;
+	let clientManager;
+	/**
+	 * A collection of a few completely random song igs that will be a valid match in a YT query
+	 */
+	let songIds = [
+		'-gd0psCIdmM',
+		'abg5DVHMAnM',
+		'ROAVuLc28IY',
+		'Zf25EAgFTCQ',
+		'OtyVp8UuN8g',
+		'ng1TapT_S9A',
+		'QFdDkIkWbx0',
+		'drLQH49ZjdY',
+		'1Qa8UolifUw',
+		'bOvy6oRBZug',
+		'ZSAMUxRS9Bw',
+		'C2LodZEUXi4',
+		'Iz1k5A8J7qU'
+	];
+
+	describe('sorting', function() {
+		beforeEach(function() {
+			clientManager = {};
+			queue = new Queue(clientManager);
+			queue.stop(); // we don't need the queue to run for those tests
+		});
+
+		beforeEach(function() {
+			client = sinon.fake()
+		});
+
+		it('should sort by most recent if votes are the same', function(next) {
+			let songIdsCopy = songIds.slice();
+
+			clientManager.emitToAll = function (event, data) {
+				// catch the "item added to queue" event
+				if (event == 'queue_info') {
+					// when all items have been added to queue
+					if (songIdsCopy.length == 0) {
+						// get the sorted items list (dont queue.items directly!)
+						let itemsSorted = queue.getItems();
+						itemsSortedIds = _.map(itemsSorted, (song) => song.youtubeId);
+
+						expect(itemsSortedIds).to.deep.eq(songIds);
+
+						return next()
+					} else {
+						// add next item to queue
+						queue.add(client, songIdsCopy.shift());
+					}
+				}
+			};
+
+			// add first item to queue
+			queue.add(client, songIdsCopy.shift());
+		});
+	})
+});


### PR DESCRIPTION
Fixes queue sorting being unpredictable. Issue: #28 
_Finally those pesky random queue shuffles will be gone!_

We were using `Array#sort`, which is apparently not "stable".

- Added `mocha`+`chai`+`sinon` test suite to reproduce/debug the issue
- Added `lodash` for a "stable" sort implementation and helpers

Note: Tests currently dont mock the Youtube Api and make API calls, API key is thus required.