### PR TITLE
Fix / Chat wiggle issues

### DIFF
--- a/public/badass-client.js
+++ b/public/badass-client.js
@@ -351,10 +351,58 @@ socket.on('song_info', function(data) {
 
 	function resetStickyMessages() {
 		$('.c-chat-history__item--sticky').hide();
+		$('.c-chat-history__messages').removeClass('c-chat-history__messages--with-sticky');
 	}
 
 	function setStickyMessage() {
 		$('.c-chat-history__item--sticky').show();
+		$('.c-chat-history__messages').addClass('c-chat-history__messages--with-sticky');
+	}
+
+	function setHistoryStartMessage() {
+		var $chatHistoryStart = $('#chat-history-start');
+		var startMessages = [
+			'It starts with one',
+			'One thing, I don\'t know why',
+			'It doesn\'t even matter how hard you try',
+			'Keep that in mind',
+			'I designed this rhyme to explain in due time',
+			'All I know',
+			'Time is a valuable thing',
+			'Watch it fly by as the pendulum swings',
+			'Watch it count down to the end of the day',
+			'The clock ticks life away',
+			'It\'s so unreal',
+			'You didn\'t look out below',
+			'Watch the time go right out the window',
+			'Tryin\' to hold on, they didn\'t even know',
+			'I wasted it all just to watch you go',
+			'I kept everything inside',
+			'And even though I tried, it all fell apart',
+			'What it meant to me will eventually be a memory',
+			'Of a time when I tried so hard',
+			'One thing, I don\'t know why',
+			'It doesn\'t even matter how hard you try',
+			'Keep that in mind, I designed this rhyme',
+			'To remind myself how I tried so hard',
+			'It\'s part of the way you were mockin\' me',
+			'Actin\' like I was part of your property',
+			'Remembering all the times you fought with me',
+			'I\'m surprised it got so far',
+			'Things aren\'t the way they were before',
+			'You wouldn\'t even recognize me anymore',
+			'Not that you knew me back then',
+			'But it all comes back to me in the end',
+			'You kept everything inside',
+			'And even though I tried, it all fell apart',
+			'What it meant to me will eventually',
+			'Be a memory of a time when I tried so hard'
+		];
+		var chosenMessages = []
+		for (var i = 0; i < 3; i++) {
+			chosenMessages.push(startMessages.splice(parseInt(startMessages.length*Math.random()), 1)[0]);
+		}
+		$chatHistoryStart.html(`<i>${chosenMessages.join('<br />')}</i>`);
 	}
 
 	function setStickyMessagePosition(e) {
@@ -398,6 +446,8 @@ socket.on('song_info', function(data) {
 			setStickyMessage($songMessage);
 		}
 	}
+
+	setHistoryStartMessage();
 
 	// add sticky message
 	var $stickyMessage = renderer._cloneTemplate('t-system-message');

--- a/public/index.html
+++ b/public/index.html
@@ -59,6 +59,7 @@
           <div class="c-chat__container">
             <div class="c-chat-history">
               <div id="chat-history" class="c-chat-history__messages">
+                <div id="chat-history-start" class="c-chat-history__start"></div>
                 <!-- t-message || t-system-message -->
               </div>
               <form action="#" class="c-message-form">

--- a/public/sass/components/components.chat.scss
+++ b/public/sass/components/components.chat.scss
@@ -25,10 +25,6 @@
   border: 1px solid var(--color-text-primary);
   border-radius: 1.5rem;
 
-  &--with-sticky-item {
-    padding-top: 4rem;
-  }
-
   &__messages {
     display: flex;
     flex-direction: column;

--- a/public/sass/components/components.chat.scss
+++ b/public/sass/components/components.chat.scss
@@ -32,6 +32,15 @@
     padding-right: .5rem;
     overflow-y: scroll;
     overflow-x: hidden;
+
+    &--with-sticky::-webkit-scrollbar-track {
+      margin-top: 2rem;
+    }
+  }
+
+  &__start {
+    margin: 100px auto;
+    text-align: center;
   }
 
   &__item {


### PR DESCRIPTION
# Problem

This PR tries to solve the chat scroll position issues specified in: #38 and more precisely the:

1)

> When song name is at the edge of the container it wiggles because reflowing changes the scroll height. Changing scroll height on the other hand triggers returning of the song to it's original place. The end result is flikering and it's bloody annoying.

2)

> when song name is at the bottom of chat container it can reflow to the top but it cannot return back since it's original position is no longer available (because of the scroll height change)

and possibly (couldn't reproduce if this is fixed, but it might very well be):

10)

> Bug with currently playing song in chat:

# Changes

- Changed the sticky message to be a separate element, so the original element can stay in chat and hold onto it's place. Not hiding the original element will visually not be a problem, since the element should be hidden from view when the sticky is visible. (we can still barely see it, but who cares)

- We now update both the sticky and the non-sticky with the currently playing song info. The sticky is updated with the new info when a new_song event comes in.

- Moved the whole `renderer` object higher up in the file, because as I started working on it it somehow became unavailable to some of the methods higher up

# Remaining issues

- The first element/message in chat will be hidden when the sticky is visible. I couldn't CSS the things correctly, so I left it as it is. It's not that big of an issue, feel free to suggest improvements for it. A downside is that the scrollbars will also be partially hidden when the sticky is shown, feel free to suggest improvements for this one too.