### PR TITLE
Feature / Chat improvements

### DIFF
--- a/public/badass-client.js
+++ b/public/badass-client.js
@@ -72,6 +72,10 @@ $('#message-submit').on('click', function(e) {
 	onMessageSubmit($('#message-input'));
 });
 
+wdtEmojiBundle.defaults.emojiSheets.apple = '//ned.im/wdt-emoji-bundle/sheets/sheet_apple_64_indexed_128.png';
+wdtEmojiBundle.defaults.type = 'apple';
+wdtEmojiBundle.init('#message-input');
+
 function onMessageSubmit($input) {
 	var value = $input.val();
 	if (!value) return;
@@ -263,9 +267,12 @@ var renderer = {
 
 		var createdShort = getTimeShort(message.created);
 		var createdLong = message.created.toISOString();
+		// note: escapes original message here, so we can use .html to show emojis in messages
+		var messageEscaped = $('<div></div>').text(message.value).html();
+		var messageWithEmojis = wdtEmojiBundle.render(messageEscaped);
 
 		$clone.find('.c-chat-history__author').text(message.author + ':');
-		$clone.find('.c-chat-history__message').text(message.value);
+		$clone.find('.c-chat-history__message').html(messageWithEmojis);
 		$clone.find('.c-chat-history__created').text(createdShort);
 		$clone.find('.c-chat-history__created').attr('title', createdLong);
 
@@ -405,7 +412,7 @@ socket.on('song_info', function(data) {
 	player.streamPlayingAt(data.playingAt);
 });
 
-// set currently playing song postion on top of mesage container
+// set currently playing song position on top of message container
 // when it's not visible
 // TODO: Soooo many corner cases. What if song persist more than once in the same list?
 (function() {

--- a/public/badass-client.js
+++ b/public/badass-client.js
@@ -251,7 +251,7 @@ var renderer = {
 			$clone.addClass('c-chat-history__item--left');
 		}
 
-		$clone.find('.c-chat-history__author').text(message.author);
+		$clone.find('.c-chat-history__author').text(message.author + ':');
 		$clone.find('.c-chat-history__message').text(message.value);
 
 		return $clone;

--- a/public/badass-client.js
+++ b/public/badass-client.js
@@ -192,6 +192,15 @@ $('body').on('click', '.js-btn-add', function() {
 	socket.emit('new_song', $(this).data('youtube-id'));
 });
 
+var getTimeShort = function (date) {
+	var hours = date.getHours();
+	var minutes = date.getMinutes();
+	var hoursPadded = hours.toString().padStart(2, '0');
+	var minutesPadded = minutes.toString().padStart(2, '0');
+
+	return [hoursPadded, minutesPadded].join(':');
+};
+
 var renderer = {
 
 	_cloneTemplate: function(templateId) {
@@ -252,7 +261,7 @@ var renderer = {
 			$clone.addClass('c-chat-history__item--left');
 		}
 
-		var createdShort = `${message.created.getHours()}:${message.created.getMinutes()}`;
+		var createdShort = getTimeShort(message.created);
 		var createdLong = message.created.toISOString();
 
 		$clone.find('.c-chat-history__author').text(message.author + ':');
@@ -288,14 +297,14 @@ var renderer = {
  * scrolled to the bottom before new message
  * is appended, or if force was specified
  * @param $message DOM element with new message
- * @param force Boolean
+ * @param forceScroll Boolean
  */
-function appendAndScrollChatToTopIfNeeded($message, force) {
-	if (typeof force === 'undefined') {
-		force = false
+function appendAndScrollChatToTopIfNeeded($message, forceScroll) {
+	if (typeof forceScroll === 'undefined') {
+		forceScroll = false;
 	}
 
-	var chatHistory = $('#chat-history')
+	var chatHistory = $('#chat-history');
 	var totalScrollAvailable = chatHistory[0].scrollHeight;
 	var currentScrollPosition = chatHistory.scrollTop() + chatHistory.height()
 
@@ -303,7 +312,7 @@ function appendAndScrollChatToTopIfNeeded($message, force) {
 		chatHistory.append($message);
 	}
 
-	if ((currentScrollPosition >= totalScrollAvailable) || force) {
+	if ((currentScrollPosition >= totalScrollAvailable) || forceScroll) {
 		chatHistory.scrollTop(999999999);
 	}
 }
@@ -318,7 +327,7 @@ socket.on('new_song', function(song) {
 	renderer.updateStickyMessage(song.info.youtubeId, song.info.title, song.info.duration);
 	$message = renderer.getChatSystemMessage(song.info.youtubeId, song.info.title, song.info.duration);
 
-	appendAndScrollChatToTopIfNeeded();
+	appendAndScrollChatToTopIfNeeded($message);
 
 	player.play(songUrlParams.url, songUrlParams);
 
@@ -504,12 +513,12 @@ function findSongSystemMessageSticky (youtubeId) {
 function addMessage(message, ownMessage) {
 	// allows date to be passed as a string
 	if (typeof message.created === 'string') {
-		message.created = new Date(message.created)
+		message.created = new Date(message.created);
 	}
 
 	var $chatHistory = $('#chat-history');
 	var $message = renderer.getChatMessage(userName, message);
-	appendAndScrollChatToTopIfNeeded($message, ownMessage)
+	appendAndScrollChatToTopIfNeeded($message, ownMessage);
 }
 
 socket.on('queue_info', function(data) {

--- a/public/badass-client.js
+++ b/public/badass-client.js
@@ -78,7 +78,8 @@ function onMessageSubmit($input) {
 
 	var message = {
 		author: userName,
-		value: value
+		value: value,
+		created: new Date() // local use only
 	};
 
 	// Send msg
@@ -251,8 +252,13 @@ var renderer = {
 			$clone.addClass('c-chat-history__item--left');
 		}
 
+		var createdShort = `${message.created.getHours()}:${message.created.getMinutes()}`;
+		var createdLong = message.created.toISOString();
+
 		$clone.find('.c-chat-history__author').text(message.author + ':');
 		$clone.find('.c-chat-history__message').text(message.value);
+		$clone.find('.c-chat-history__created').text(createdShort);
+		$clone.find('.c-chat-history__created').attr('title', createdLong);
 
 		return $clone;
 	},

--- a/public/index.html
+++ b/public/index.html
@@ -69,7 +69,7 @@
                 <!-- t-message || t-system-message -->
               </div>
               <form action="#" class="c-message-form">
-                <input type="textarea" id="message-input" class="c-input-basic c-input-basic--with-icon wdt-emoji-open-on-colon" placeholder="Type your message here...">
+                <input type="textarea" id="message-input" class="c-input-basic wdt-emoji-open-on-colon" placeholder="Type your message here...">
                 <button id="message-submit" class="c-btn c-message-form__submit">
                   <span class="c-icon c-icon--small c-icon--bordered">
                     <i class="c-icon__content c-icon__content--chat"></i>
@@ -187,7 +187,7 @@
                 <h2 class="u-h2">Please ener your (nick) name</h2>
                 <h3 class="u-h3 u-h-secondary u-mb-small">(It will be visible for all CDRadio users)</h3>
               </label>
-              <input type="text" id="username-input" class="c-input-basic" placeholder="Your (nick) name"> 
+              <input type="text" id="username-input" class="c-input-basic" placeholder="Your (nick) name">
             </div>
             <div class="c-username-form__content-item--secondary">
               <div class="u-h3 u-h-secondary u-center">- or -</div>
@@ -224,7 +224,7 @@
       <div class="c-chat-history__item c-chat-history__item--right c-chat-history__item--system">
         <span class="c-chat-history__author">Now Playing:</span>
         <div class="c-chat-history__message">
-          <span class="c-chat-history__text">-</span> - 
+          <span class="c-chat-history__text">-</span> -
           <span class="c-chat-history__timer">-</span>
         </div>
       </div>

--- a/public/index.html
+++ b/public/index.html
@@ -210,6 +210,7 @@
       <div class="c-chat-history__item">
         <span class="c-chat-history__author">-</span>
         <div class="c-chat-history__message">-</div>
+        <div class="c-chat-history__created"></div>
       </div>
     </template>
 

--- a/public/index.html
+++ b/public/index.html
@@ -60,6 +60,11 @@
             <div class="c-chat-history">
               <div id="chat-history" class="c-chat-history__messages">
                 <div id="chat-history-start" class="c-chat-history__start"></div>
+                <div id="chat-history-new-message" class="c-chat-history__new-message">
+                  <div class="c-chat-history__item">
+                    <div class="c-chat-history__message">New message (Click to see)</div>
+                  </div>
+                </div>
                 <!-- t-message || t-system-message -->
               </div>
               <form action="#" class="c-message-form">

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
 
     <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400" rel="stylesheet">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/JavaScript-autoComplete/1.0.4/auto-complete.min.css" />
+    <link rel="stylesheet" href="//ned.im/wdt-emoji-bundle/wdt-emoji-bundle.css" />
     <link href="/css/style.css" rel="stylesheet">
     <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <title>CDR &mdash; your splice of music</title>
@@ -68,7 +69,7 @@
                 <!-- t-message || t-system-message -->
               </div>
               <form action="#" class="c-message-form">
-                <input type="textarea" id="message-input" class="c-input-basic c-input-basic--with-icon" placeholder="Type your message here...">
+                <input type="textarea" id="message-input" class="c-input-basic c-input-basic--with-icon wdt-emoji-open-on-colon" placeholder="Type your message here...">
                 <button id="message-submit" class="c-btn c-message-form__submit">
                   <span class="c-icon c-icon--small c-icon--bordered">
                     <i class="c-icon__content c-icon__content--chat"></i>
@@ -255,7 +256,47 @@
       </li>
     </template>
 
+    <div class="wdt-emoji-popup">
+      <a href="#" class="wdt-emoji-popup-mobile-closer"> × </a>
+      <div class="wdt-emoji-menu-content">
+        <div id="wdt-emoji-menu-header">
+          <a class="wdt-emoji-tab active" data-group-name="Recent"></a>
+          <a class="wdt-emoji-tab" data-group-name="People"></a>
+          <a class="wdt-emoji-tab" data-group-name="Nature"></a>
+          <a class="wdt-emoji-tab" data-group-name="Foods"></a>
+          <a class="wdt-emoji-tab" data-group-name="Activity"></a>
+          <a class="wdt-emoji-tab" data-group-name="Places"></a>
+          <a class="wdt-emoji-tab" data-group-name="Objects"></a>
+          <a class="wdt-emoji-tab" data-group-name="Symbols"></a>
+          <a class="wdt-emoji-tab" data-group-name="Flags"></a>
+          <a class="wdt-emoji-tab" data-group-name="Custom"></a>
+        </div>
+        <div class="wdt-emoji-scroll-wrapper">
+          <div id="wdt-emoji-menu-items">
+            <input id="wdt-emoji-search" type="text" placeholder="Search">
+            <h3 id="wdt-emoji-search-result-title">Search Results</h3>
+            <div class="wdt-emoji-sections"></div>
+            <div id="wdt-emoji-no-result">No emoji found</div>
+          </div>
+        </div>
+        <div id="wdt-emoji-footer">
+          <div id="wdt-emoji-preview">
+            <span id="wdt-emoji-preview-img"></span>
+            <div id="wdt-emoji-preview-text">
+              <span id="wdt-emoji-preview-name"></span><br>
+              <span id="wdt-emoji-preview-aliases"></span>
+            </div>
+          </div>
+          <div id="wdt-emoji-preview-bundle">
+            <span>WDT Emoji Bundle</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <script src="/socket.io/socket.io.js"></script>
+    <script src="//ned.im/wdt-emoji-bundle/emoji.min.js"></script>
+    <script src="//ned.im/wdt-emoji-bundle/wdt-emoji-bundle.min.js"></script>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/JavaScript-autoComplete/1.0.4/auto-complete.min.js"></script>
     <script src="//unpkg.com/popper.js/dist/umd/popper.min.js"></script>

--- a/public/sass/components/components.chat.scss
+++ b/public/sass/components/components.chat.scss
@@ -12,9 +12,14 @@
     position: relative;
   }
 
+  // wdt emoji picker components styles
   .wdt-emoji-picker {
     right: 3.8rem;
     bottom: 1rem;
+  }
+
+  .wdt-emoji-open-on-colon {
+    padding-right: 6rem;
   }
 }
 

--- a/public/sass/components/components.chat.scss
+++ b/public/sass/components/components.chat.scss
@@ -13,6 +13,11 @@
   }
 }
 
+.c-chat .wdt-emoji-picker {
+  right: 38px;
+  bottom: 10px;
+}
+
 .c-chat-history {
   position: absolute; // --sticky-top items is relative to that
   top: 0;

--- a/public/sass/components/components.chat.scss
+++ b/public/sass/components/components.chat.scss
@@ -62,6 +62,10 @@
       margin-right: auto;
       border-top-left-radius: initial;
     }
+
+    &--system {
+      background-color: var(--color-primary)
+    }
   }
 
   &__item--inverse {

--- a/public/sass/components/components.chat.scss
+++ b/public/sass/components/components.chat.scss
@@ -100,6 +100,13 @@
     word-wrap: break-word;
   }
 
+  &__created {
+    margin-left: auto;
+    font-size: 1rem;
+    height: 1rem;
+    color: var(--color-text-silver-light);
+  }
+
   &__timer {
     font-style: italic;
   }

--- a/public/sass/components/components.chat.scss
+++ b/public/sass/components/components.chat.scss
@@ -43,6 +43,21 @@
     text-align: center;
   }
 
+  &__new-message {
+    position: absolute;
+    bottom: 60px;
+    width: 100%;
+    display: none;
+  }
+
+  &__new-message .c-chat-history__item {
+    margin: 0 auto;
+    width: 140px;
+    text-align: center;
+    background-color: var(--color-primary);
+    cursor: pointer;
+  }
+
   &__item {
     display: flex;
     flex: 0 0 auto;

--- a/public/sass/components/components.chat.scss
+++ b/public/sass/components/components.chat.scss
@@ -76,6 +76,10 @@
     color: var(--color-text-silver-dark);
   }
 
+  &__item--inverse &__created {
+    color: var(--color-text-silver-dark);
+  }
+
   &__item--inverse &__message {
     color: var(--color-primary);
   }

--- a/public/sass/components/components.chat.scss
+++ b/public/sass/components/components.chat.scss
@@ -11,11 +11,11 @@
     padding-top: 85%;
     position: relative;
   }
-}
 
-.c-chat .wdt-emoji-picker {
-  right: 38px;
-  bottom: 10px;
+  .wdt-emoji-picker {
+    right: 3.8rem;
+    bottom: 1rem;
+  }
 }
 
 .c-chat-history {
@@ -50,17 +50,17 @@
 
   &__new-message {
     position: absolute;
-    bottom: 60px;
+    bottom: 6rem;
     width: 100%;
     display: none;
-  }
 
-  &__new-message .c-chat-history__item {
-    margin: 0 auto;
-    width: 140px;
-    text-align: center;
-    background-color: var(--color-primary);
-    cursor: pointer;
+    .c-chat-history__item {
+      margin: 0 auto;
+      width: 14rem;
+      text-align: center;
+      background-color: var(--color-primary);
+      cursor: pointer;
+    }
   }
 
   &__item {

--- a/server/core/chat.js
+++ b/server/core/chat.js
@@ -26,6 +26,7 @@ class Chat {
 
 		//Bind events to this user:
 		client.on('chat_msg', data => {
+			data.created = new Date();
 			this.newMessage(client, data);
 		});
 	}


### PR DESCRIPTION
Related to: #49 

- Added message timestamps. Style is a bit off, it takes space from the actual text, so any suggestions are welcome.
![image](https://user-images.githubusercontent.com/6020242/52918119-355dd500-32fc-11e9-8a37-6e1f9ebfa257.png)

- Added colon after the user name. That was easy enough
![image](https://user-images.githubusercontent.com/6020242/52918127-51fa0d00-32fc-11e9-89c5-1bc00773b344.png)

- Added different color for system messages (Now playing). It will use the primary color, which is usually a bit more richer in color, excep for the PlayStrip theme, where it's transparent. Still not looking too bad.
![image](https://user-images.githubusercontent.com/6020242/52918305-2546f500-32fe-11e9-8525-296ef335510a.png)
![image](https://user-images.githubusercontent.com/6020242/52918402-422ff800-32ff-11e9-8ab1-94bc3d5552ea.png)

- Fixed chat scrolling while manually scrolled up and autoscroll not needed. 
  - Chat will now **not** autoscroll for a new message if the user has scrolled up manually (reading previous conversations)
  - Writing a new message **will** scroll down the chat to the latest written message
  - A "New message (Click to see)" notice will be shown, if a new message has been received, while user is scrolled up and has thus missed it (only for non-system chat messages)
![image](https://user-images.githubusercontent.com/6020242/52918952-d8ffb300-3305-11e9-920f-ec8516de757f.png)
- Emoji list
  - Using https://github.com/needim/wdt-emoji-bundle for now. It has a few known bugs, so let's see how it goes
![image](https://user-images.githubusercontent.com/6020242/53299055-7bf08980-383e-11e9-9859-8fd5f1958ee2.png)
  - Known bugs:
    - Top menu (emotji category switches) have their hitboxes offset to the left? Probably because of the changes to the picker icon?
    - Emojis don't render in the input field, and show text representation instead. We could render them manually, but it would probably cause a lot of issues. I don't feel too bad about this.



Want to do, but will do in another PR.
- Images rendered in chat
  - Pretty sure I want to limit those to show only `https://giphy.com/*` and `https://imgur.com/*`
- Reactions
  The idea is to use the emoji picker from the chat to have slack-like reactions to each messages. In order to do this the server code would have to be restructured a bit - reactions need to be added to the chat messages. In order to do this cleanly I have a few ideas for adding the reactions as a component/mixin/whatever to the chat, which might change the current architecture of the relationship between the `Chat` and `ChatManager` classes, as well as the `Queue`, `QueueManager` and `VotesManager` classes. Will present those in another PR.